### PR TITLE
added gps location from gpsgate on voertuig for vrgz

### DIFF
--- a/public/js/safetymaps/config/options.js
+++ b/public/js/safetymaps/config/options.js
@@ -1,11 +1,3 @@
-/*
-    * CHANGELOG
-    *
-    * 20191120 BV
-    * For some reason geolocate from OpenLayers does not always work on all devices
-    * Therefore an extra option is added to the module config 'provider:gpsgate'
-    * This option connects to an local javascript file from FransonGPSgate and gets the Windows Location LonLat
-*/
 
 var dbkjs = dbkjs || {};
 window.dbkjs = dbkjs;
@@ -68,8 +60,5 @@ dbkjs.options = {
     
     resetToDefaultOnIncident: false,
     
-    showLayerLoadingPanel: true,
-
-    useGPSGateAsFallbackOnVoertuig: false,
-    gpsGateURL: 'http://localhost:12175/javascript/GpsGate.js'
+    showLayerLoadingPanel: true
 };

--- a/public/js/safetymaps/config/options.js
+++ b/public/js/safetymaps/config/options.js
@@ -1,3 +1,11 @@
+/*
+    * CHANGELOG
+    *
+    * 20191120 BV
+    * For some reason geolocate from OpenLayers does not always work on all devices
+    * Therefore an extra option is added to the module config 'provider:gpsgate'
+    * This option connects to an local javascript file from FransonGPSgate and gets the Windows Location LonLat
+*/
 
 var dbkjs = dbkjs || {};
 window.dbkjs = dbkjs;
@@ -60,5 +68,8 @@ dbkjs.options = {
     
     resetToDefaultOnIncident: false,
     
-    showLayerLoadingPanel: true
+    showLayerLoadingPanel: true,
+
+    useGPSGateAsFallbackOnVoertuig: false,
+    gpsGateURL: 'http://localhost:12175/javascript/GpsGate.js'
 };


### PR DESCRIPTION
GPS location on an onboard device is not always accurate available through chrome/openlayers.geolocate. Therefore i've added an extra option in modules/geolocate for reading the GPS location from GPSgate whitch is already available on all onboard devices. 

For this i've also added 2 options in config/options. These options are not set here and needs to be set in customize.js (for vrgz like this):

if(vrgz.isVoertuig) {
    dbkjs.options.useGPSGateAsFallbackOnVoertuig = true;
    dbkjs.options.gpsGateURL = [url];
}
