### PR TITLE
Bugfix on active vehicle position from SafetyConnect

### DIFF
--- a/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
+++ b/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
@@ -926,7 +926,9 @@ VehicleIncidentsController.prototype.updateVehiclePositionsSC = function() {
         var transformedVehicles = data.features
             .filter(function(f) {
                 // Filter only vehicles for incident inzet
-                return f.properties.incidentNummer === me.incident.IncidentNummer;
+                return me.incident.BetrokkenEenheden.filter(function (be) {
+                    return be.IsActief && be.Roepnaam === f.properties.id;
+                }).length > 0;
             })
             .map(function(f) {
                 // Map SC vehicles schema to schema expected by VehiclePositionLayer


### PR DESCRIPTION
SafetyConnect gives first active incident for vehicle even if vehicle is not active on that incident.
Therefore the check on IncidentNummer as before is not correct.