### PR TITLE
Use a comma seperated list as voertuignummers

### DIFF
--- a/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
+++ b/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
@@ -492,6 +492,9 @@ VehicleIncidentsController.prototype.setVoertuignummer = function(voertuignummer
         voertuignummers = [""];
     } else {
         voertuignummers = voertuignummer.split(/[,; ]/);
+        voertuignummers = voertuignummers.filter(function(f) {
+            return v !== "";
+        })
     }
     me.voertuignummers = voertuignummers;
 

--- a/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
+++ b/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
@@ -491,9 +491,9 @@ VehicleIncidentsController.prototype.setVoertuignummer = function(voertuignummer
     if (!voertuignummer || voertuignummer === '') {
         voertuignummers = [""];
     } else {
-        voertuignummers = voertuignummer.split(";").join(",").split(" ").join(",");
+        voertuignummers = voertuignummer.split(/[,; ]/);
     }
-    me.voertuignummers = voertuignummers.split(",");
+    me.voertuignummers = voertuignummers;
 
     me.voertuignummer = me.voertuignummers[0];
     window.localStorage.setItem("voertuignummer", voertuignummer);

--- a/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
+++ b/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
@@ -491,10 +491,7 @@ VehicleIncidentsController.prototype.setVoertuignummer = function(voertuignummer
     if (!voertuignummer || voertuignummer === '') {
         voertuignummers = [""];
     } else {
-        voertuignummers = voertuignummer.split(/[,; ]/);
-        voertuignummers = voertuignummers.filter(function(f) {
-            return v !== "";
-        })
+        voertuignummers = voertuignummer.split(/[,; ]+/);
     }
     me.voertuignummers = voertuignummers;
 


### PR DESCRIPTION
- Seperate voertuignummers by comma, semicolumn or white space.
- The first voertuignummer is the fallback.
- When checking for new incidents the voertuignummers will be looped from left to right until a incident is found. When a incident is found for a voertuignummer that voertuignummer is set and not changed until the incident is closed. Then the fallback voertuignummer will be set.