### PR TITLE
Retry VrhAGS initialization

### DIFF
--- a/public/js/safetymaps/modules/incidents/AGSIncidentService.js
+++ b/public/js/safetymaps/modules/incidents/AGSIncidentService.js
@@ -88,7 +88,12 @@ AGSIncidentService.prototype.whenInitialized = function() {
     if(this.initialized) {
         d.resolve();
     } else {
+        var timeout = window.setTimeout(function() {
+            d.reject();
+        }, 5000);
+
         $(me).on("initialized", function() {
+            window.clearTimeout(timeout);
             d.resolve();
         });
     }


### PR DESCRIPTION
Should solve the problem when VrhAGS is offline on viewer load no incident info is ever shown. The `getVoertuigIncidentVrhAGS()` promise did not reject after a timeout. With this change it should use the SC fallback.