### PR TITLE
Fix/strange behaviour on fotofunction in offline viewer

### DIFF
--- a/public/js/safetymaps/modules/fotoFunction.js
+++ b/public/js/safetymaps/modules/fotoFunction.js
@@ -80,6 +80,7 @@ dbkjs.modules.fotoFunction = {
     },
 
     clearTimer: function () {
+        var me = this;
         if(me.updateFotoTimeout) {
             window.clearInterval(me.updateFotoTimeout);
             me.updateFotoTimeout = null;


### PR DESCRIPTION
In a offline viewer like VRLN the event incident_end is never fired. Therefore the getFotoForIncident timer was not destroyed. And resulted in multiple active timers.