### PR TITLE
Revert "FB-1082 lowercase status code"

### DIFF
--- a/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
+++ b/public/js/safetymaps/modules/incidents/VehicleIncidentsController.js
@@ -701,12 +701,12 @@ VehicleIncidentsController.prototype.showStatusVrhAGS = function() {
         if(status) {
             me.options.logStatus && console.log("VrhAGS: Voertuigstatus", status);
             var id = status.T_ACT_STATUS_CODE_EXT_BRW;
-            var code = status.T_ACT_STATUS_AFK_BRW.toLowerCase();
+            var code = status.T_ACT_STATUS_AFK_BRW;
 
             switch(code) {
-                case "ut": code = "ug"; break;
-                case "kz": code = "ok"; break;
-                case "ir": code = "ni"; break;
+                case "UT": code = "UG"; break;
+                case "KZ": code = "OK"; break;
+                case "IR": code = "NI"; break;
             }
 
             $("<div id='status'>" + id + ": " + code + "</div>").prependTo("body");


### PR DESCRIPTION
This reverts commit 02c397ca35dd2b43e5b54fc73efc0dac17f41d93.

Rationale: the statuses will be lowercased in the table, and at that same time the `switch` to replace statuses is also not desired anymore. Before that happens, the uppercase statuses should still be replaced by the `switch` statement.